### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "graham-campbell/manager": "^4.5",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^v8.0.0|v10.39.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|v10.39.0",
         "vanthao03596/ghtk-sdk": "^0.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
Fix Problem:
    - Root composer.json requires vanthao03596/laravel-ghtk * -> satisfiable by vanthao03596/laravel-ghtk[dev-main, 0.0.1, 9999999-dev].
    - vanthao03596/laravel-ghtk[dev-main, 0.0.1] require illuminate/contracts ^6.0|^7.0|^8.0 -> found illuminate/contracts[v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev] but these were not loaded, likely because it conflicts with another require.